### PR TITLE
Refactor text drawing in SkiaCanvas.cs

### DIFF
--- a/Mapsui.Demo.WPF/MainWindow.xaml
+++ b/Mapsui.Demo.WPF/MainWindow.xaml
@@ -2,7 +2,7 @@
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-        xmlns:xaml="clr-namespace:Mapsui.UI.WPF;assembly=Mapsui.UI.WPF"
+        xmlns:xaml="clr-namespace:Mapsui.UI.Wpf;assembly=Mapsui.UI.Wpf"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:local="clr-namespace:Mapsui.Demo.WPF"
         mc:Ignorable="d"

--- a/VectorTileRenderer/SkiaCanvas.cs
+++ b/VectorTileRenderer/SkiaCanvas.cs
@@ -407,16 +407,15 @@ namespace VectorTileRenderer
             int i = 0;
             foreach (var line in allLines)
             {
-                var bytes = Encoding.UTF32.GetBytes(line);
                 float lineOffset = (float)(i * style.Paint.TextSize) - ((float)(allLines.Length) * (float)style.Paint.TextSize) / 2 + (float)style.Paint.TextSize;
                 var position = new SKPoint((float)geometry.X + (float)(style.Paint.TextOffset.X * style.Paint.TextSize), (float)geometry.Y + (float)(style.Paint.TextOffset.Y * style.Paint.TextSize) + lineOffset);
 
                 if (style.Paint.TextStrokeWidth != 0)
                 {
-                    canvas.DrawText(bytes, position, strokePaint);
+                    canvas.DrawText(line, position, strokePaint);
                 }
 
-                canvas.DrawText(bytes, position, paint);
+                canvas.DrawText(line, position, paint);
                 i++;
             }
         }
@@ -517,10 +516,10 @@ namespace VectorTileRenderer
             var bytes = Encoding.UTF32.GetBytes(text);
             if (style.Paint.TextStrokeWidth != 0)
             {
-                canvas.DrawTextOnPath(bytes, path, offset, getTextStrokePaint(style));
+                canvas.DrawTextOnPath(text, path, offset, getTextStrokePaint(style));
             }
 
-            canvas.DrawTextOnPath(bytes, path, offset, getTextPaint(style));
+            canvas.DrawTextOnPath(text, path, offset, getTextPaint(style));
         }
 
         public void DrawPoint(Point geometry, Brush style)


### PR DESCRIPTION
Replaced byte encoding with direct string usage in canvas.DrawText and canvas.DrawTextOnPath methods, simplifying the code and improving readability.